### PR TITLE
Fix Compile error

### DIFF
--- a/alvr/server/cpp/platform/linux/CEncoder.cpp
+++ b/alvr/server/cpp/platform/linux/CEncoder.cpp
@@ -6,7 +6,7 @@
 #include <exception>
 #include <iterator>
 #include <memory>
-#include <drm/drm_fourcc.h>
+#include <libdrm/drm_fourcc.h>
 
 #include "ALVR-common/packet_types.h"
 #include "alvr_server/ClientConnection.h"


### PR DESCRIPTION
include should use libdrm, as the drm include path might not be available